### PR TITLE
pass in the Queue constructor for bullmq

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,6 @@ Arena({
     return Bee || (Bee = require('bee-queue'));
   },
   get BullMQ() {
-    return BullMQ || (BullMQ = require('bullmq'));
+    return BullMQ || (BullMQ = (require('bullmq')).Queue);
   },
 });


### PR DESCRIPTION
This PR addresses the default import for bullmq not being the correct Queue constructor that's required to be passed into the Arena constructor.

## Testing
with the following config file:
```json
// arena.json
{
  "queues": [
    {
      "name": "node-ts/bus-redis-test",
      "hostId": "Integration test queue",
      "type": "bullmq",
      "redis": {
          "port": 6379,
          "host": "redis"
      }
    }
  ]
}
```

Accompanied with a `docker-compose.yml` to assist with networking:

```yml
# docker-compose.yml
version: '3'

services:
  redis:
    image: bitnami/redis
    container_name: redis
    environment:
      - ALLOW_EMPTY_PASSWORD=yes
    ports:
      - "6379:6379"
  arena:
    image: docker-arena
    container_name: arena
    links:
      - redis
    ports:
      - "4567:4567"
    volumes:
      - "./arena.json:/opt/arena/index.json"
```

it would fail the moment you try to access the specified queue in the UI with the following error message:

![2021-08-02 22 08 12](https://user-images.githubusercontent.com/18492498/127859717-2c997571-a5cc-4e11-b8b8-ecf625393704.gif)

![image](https://user-images.githubusercontent.com/18492498/127859086-f1cd4cd4-17ad-4987-bdf2-590a86304f8d.png)

Specifically `BullMQ is not a constructor`.

## With the fix
![2021-08-02 22 14 54](https://user-images.githubusercontent.com/18492498/127860511-20cc0fd0-3391-4a6e-95c1-dcce0bc82102.gif)
