### PR TITLE
Fix support for BullMQ

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,6 @@ Arena({
     return Bee || (Bee = require('bee-queue'));
   },
   get BullMQ() {
-    return BullMQ || (BullMQ = require('bullmq'));
+    return BullMQ || (BullMQ = require('bullmq').Queue);
   },
 });


### PR DESCRIPTION
Per #209, the `bullmq` package doesn't return a single constructor, so docker-arena needs to instantiate the `Queue` class specifically.